### PR TITLE
Fix token handling and Docker plugin check in Telegraf updater

### DIFF
--- a/telegraf-setup-scripts/update-telegraf-w-keys.sh
+++ b/telegraf-setup-scripts/update-telegraf-w-keys.sh
@@ -3,7 +3,13 @@
 set -e
 
 # === CONFIGURATION ===
-TOKEN="$HOSTNAME"
+TOKEN_FILE="/run/secrets/${HOSTNAME}"
+if [[ -r "$TOKEN_FILE" ]]; then
+  TOKEN="$(sudo cat "$TOKEN_FILE")"
+else
+  echo "[✗] Docker secret $TOKEN_FILE not found or unreadable." >&2
+  exit 1
+fi
 BUCKET="Home_Network"
 ORG="Home Network"
 URL="http://docker2:8086"
@@ -35,7 +41,7 @@ EOF
 fi
 
 echo "[+] Checking for Docker plugin..."
-if ! grep -q '\[\[inputs.docker\]\]' "$TELEGRAF_CONF"; then
+if ! sudo grep -q '^\s*\[\[inputs.docker\]\]' "$TELEGRAF_CONF"; then
 cat <<EOF | sudo tee -a "$TELEGRAF_CONF" > /dev/null
 
 [[inputs.docker]]


### PR DESCRIPTION
## Summary
- Read InfluxDB token from Docker secret matching the host name
- Correctly detect and append Telegraf Docker input plugin

## Testing
- `bash -n telegraf-setup-scripts/update-telegraf-w-keys.sh`
- `shellcheck telegraf-setup-scripts/update-telegraf-w-keys.sh`


------
https://chatgpt.com/codex/tasks/task_e_68950526a1d48323b5f8c7c978f77197