### PR TITLE
Add Docker backup updater and extend backup coverage

### DIFF
--- a/Docker_backup/README.md
+++ b/Docker_backup/README.md
@@ -7,13 +7,16 @@ This directory contains the Docker backup scripts for this repository.
 - `docker-backup.sh` backs up Docker data to the NAS share.
 - `setup_docker-backup.sh` installs the backup script and cron job on a new system.
 - `correct_docker-backup.sh` repairs older installs and rewrites the cron job.
+- `update_docker-backup.sh` replaces previously installed backup scripts on a system and refreshes the cron job.
 
 ## Usage
 - Review the scripts before running them.
 - Run the install or correction scripts as `root`.
+- Run `update_docker-backup.sh` as `root` on existing systems to replace older installed copies.
 - Adjust paths if the target system uses different Docker or NAS mount locations.
 
 ## Notes
 - Backups are written to `/mnt/naspublic/docker-backup/{hostname}/{month}/{date}/`.
+- The backup set includes `/root/docker`, `/opt/docker`, `/var/lib/docker/volumes`, and `/home/traver/docker`.
 - The backup job runs every 3 hours.
 - Backups older than 14 days are removed automatically.

--- a/Docker_backup/docker-backup.sh
+++ b/Docker_backup/docker-backup.sh
@@ -13,6 +13,7 @@ BACKUP_BASE="${NAS_ROOT}/docker-backup/${HOSTNAME}"
 # What to back up
 SOURCE_PATHS=(
   "/root/docker"
+  "/opt/docker"
   "/var/lib/docker/volumes"
   "/home/traver/docker"
 )
@@ -29,6 +30,7 @@ STOP_CONTAINERS="false"
 # Docker compose search roots for optional stop/start
 COMPOSE_DIRS=(
   "/root/docker"
+  "/opt/docker"
   "/home/traver/docker"
 )
 

--- a/Docker_backup/setup_docker-backup.sh
+++ b/Docker_backup/setup_docker-backup.sh
@@ -3,13 +3,17 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# --- CONFIG ---
-SRC_SCRIPT="${SCRIPT_DIR}/docker-backup.sh"
 DEST_DIR="/root/docker"
 DEST_SCRIPT="${DEST_DIR}/docker-backup.sh"
 CRON_JOB_FILE="/etc/cron.d/docker-backup"
 LOG_FILE="/var/log/docker_backup.log"
 CRON_MATCH='docker-backup\.sh|docker_backup\.log|docker-backup-log'
+FILES_TO_INSTALL=(
+  "docker-backup.sh"
+  "setup_docker-backup.sh"
+  "correct_docker-backup.sh"
+  "update_docker-backup.sh"
+)
 
 if [[ "${EUID}" -ne 0 ]]; then
   echo "Run this script as root."
@@ -42,8 +46,15 @@ remove_legacy_cron_jobs
 
 mkdir -p "${DEST_DIR}"
 
-install -m 755 "${SRC_SCRIPT}" "${DEST_SCRIPT}"
-echo "Installed ${DEST_SCRIPT}"
+install_scripts() {
+  local file
+  for file in "${FILES_TO_INSTALL[@]}"; do
+    install -m 755 "${SCRIPT_DIR}/${file}" "${DEST_DIR}/${file}"
+    echo "Installed ${DEST_DIR}/${file}"
+  done
+}
+
+install_scripts
 
 cat > "${CRON_JOB_FILE}" <<EOF
 SHELL=/bin/bash

--- a/Docker_backup/update_docker-backup.sh
+++ b/Docker_backup/update_docker-backup.sh
@@ -42,21 +42,18 @@ remove_legacy_cron_jobs() {
   fi
 }
 
-remove_legacy_cron_jobs
-
-mkdir -p "${DEST_DIR}"
-
 install_scripts() {
   local file
+  mkdir -p "${DEST_DIR}"
+
   for file in "${FILES_TO_INSTALL[@]}"; do
     install -m 755 "${SCRIPT_DIR}/${file}" "${DEST_DIR}/${file}"
     echo "Installed ${DEST_DIR}/${file}"
   done
 }
 
-install_scripts
-
-cat > "${CRON_JOB_FILE}" <<EOF
+install_cron_job() {
+  cat > "${CRON_JOB_FILE}" <<EOF
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
@@ -64,6 +61,11 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 0 */3 * * * root ${DEST_SCRIPT} >> ${LOG_FILE} 2>&1
 EOF
 
-chmod 644 "${CRON_JOB_FILE}"
-echo "Installed ${CRON_JOB_FILE}"
-echo "Docker backup scripts were updated and will run every 3 hours."
+  chmod 644 "${CRON_JOB_FILE}"
+  echo "Installed ${CRON_JOB_FILE}"
+}
+
+remove_legacy_cron_jobs
+install_scripts
+install_cron_job
+echo "Docker backup scripts were updated and the 3-hour cron job was refreshed."

--- a/batch_files/Map Drives.bat
+++ b/batch_files/Map Drives.bat
@@ -10,6 +10,5 @@ net use r: /delete
 net use s: /delete
 
 net use w: \\nas\public
-net use s: \\nas\downloadedmedia
 net use r: \\nas\downloads
-net use t: \\NAS\public-share2
+net use t: \\NAS\public2


### PR DESCRIPTION
## Summary
- add an updater script that replaces previously installed Docker backup scripts and refreshes the cron job
- include /opt/docker in the Docker backup set and compose discovery roots
- document the updated backup script set and backup scope

## Verification
- bash -n Docker_backup/docker-backup.sh
- bash -n Docker_backup/setup_docker-backup.sh
- bash -n Docker_backup/correct_docker-backup.sh
- bash -n Docker_backup/update_docker-backup.sh