### PR TITLE
Fix Docker backup install mode detection and log messaging

### DIFF
--- a/Docker_backup/setup_docker-backup.sh
+++ b/Docker_backup/setup_docker-backup.sh
@@ -21,8 +21,8 @@ if [[ "${EUID}" -ne 0 ]]; then
 fi
 
 detect_mode() {
-  # If any prior install artifact exists, treat this run as an update.
-  if [[ -f "${DEST_SCRIPT}" || -f "${CRON_JOB_FILE}" || -d "${DEST_DIR}" ]]; then
+  # Treat as update only when concrete install artifacts are present.
+  if [[ -f "${DEST_SCRIPT}" || -f "${CRON_JOB_FILE}" ]]; then
     echo "update"
   else
     echo "first-time"
@@ -68,9 +68,9 @@ install_scripts() {
 install_scripts
 
 if [[ "${MODE}" == "first-time" ]]; then
-  echo "Detected first-time install. Applying Docker backup setup."
+  echo "No existing Docker backup install detected. Installing Docker backup scripts and cron configuration."
 else
-  echo "Detected existing install. Applying Docker backup update to the latest config."
+  echo "Existing Docker backup install detected. Reinstalling Docker backup scripts and refreshing cron configuration."
 fi
 
 cat > "${CRON_JOB_FILE}" <<EOF


### PR DESCRIPTION
## Summary
- Update install mode detection to rely on concrete install artifacts only
- Remove directory-existence check from detect_mode to avoid false update classification
- Clarify first-time vs existing-install messages to match actual behavior (both paths reinstall scripts and refresh cron)

## Verification
- Ran bash -n Docker_backup/setup_docker-backup.sh
- Reviewed diff to confirm only targeted changes were included