### PR TITLE
fix: robust hs binary search in tile-windows.applescript

### DIFF
--- a/mac-scripts/tile-windows/README.md
+++ b/mac-scripts/tile-windows/README.md
@@ -19,6 +19,8 @@ brew install --cask hammerspoon
 ```
 Open Hammerspoon and **grant Accessibility permission** in System Settings → Privacy & Security → Accessibility.
 
+> **Note:** The clickable `.app` searches these known `hs` binary locations automatically: `/opt/homebrew/bin/hs`, `/usr/local/bin/hs`, `/opt/local/bin/hs`, and the Hammerspoon Caskroom path. This is necessary because AppleScript's `do shell script` runs with a minimal PATH that doesn't include your interactive shell's PATH.
+
 ### 2. Install the config
 ```bash
 # Back up existing config if you have one

--- a/mac-scripts/tile-windows/tile-windows.applescript
+++ b/mac-scripts/tile-windows/tile-windows.applescript
@@ -4,23 +4,50 @@
 --
 -- REQUIREMENTS:
 --   1. Hammerspoon must be installed and running (https://hammerspoon.org)
---   2. This file's companion init.lua must be loaded in ~/.hammerspoon/init.lua
+--   2. This file's companion hammerspoon-init.lua must be loaded in ~/.hammerspoon/init.lua
 --   3. In Hammerspoon → Preferences → "Enable CLI (IPC Server)" must be checked
---      (this registers the `hs` command on your PATH)
+--      (this registers the `hs` command so this script can invoke it)
 --
 -- BUILD INSTRUCTIONS (creates a double-clickable .app):
 --   Open Script Editor.app → File → Open... navigate to this file.
 --   Or use osacompile from Terminal:
 --     osacompile -o ~/Applications/Tile\ Windows.app tile-windows.applescript
 --   Then double-click "Tile Windows.app" in Finder/Dock to run it.
+--
+-- NOTE: `do shell script` in AppleScript runs with a minimal PATH,
+-- so we search known install locations for the `hs` binary.
+
+property hsBinaryPaths : { ¬
+	"/opt/homebrew/bin/hs", ¬
+	"/usr/local/bin/hs", ¬
+	"/opt/local/bin/hs", ¬
+	"/opt/homebrew/Caskroom/hammerspoon/latest/Hammerspoon.app/Contents/Resources/hs" ¬
+}
+
+on findHsBinary()
+	repeat with p in hsBinaryPaths
+		try
+			do shell script "test -x " & quoted form of p
+			return p
+		end try
+	end repeat
+	return ""
+end findHsBinary
+
+set hsPath to findHsBinary()
+
+if hsPath is "" then
+	display notification "Hammerspoon CLI (hs) not found. Install Hammerspoon and enable IPC Server in Preferences." with title "Tile Windows" subtitle "❌"
+	return
+end if
 
 try
-  set resultText to do shell script "/opt/homebrew/bin/hs -c 'tileTwoWindows()'"
+	do shell script quoted form of hsPath & " -c 'tileTwoWindows()'"
 on error errMsg number errNum
-  -- If the IPC call fails, fall back to a friendly notification
-  display notification "Could not reach Hammerspoon IPC. Make sure Hammerspoon is running and IPC Server is enabled." with title "Tile Windows" subtitle "❌"
-  return
+	-- If the IPC call fails, it likely means Hammerspoon isn't running
+	display notification "Could not reach Hammerspoon. Make sure Hammerspoon is running and IPC Server is enabled." with title "Tile Windows" subtitle "❌"
+	return
 end try
 
--- Optional: brief visual confirmation
+-- Brief visual confirmation
 display notification "Windows tiled ✓" with title "Tile Windows"


### PR DESCRIPTION
Search multiple known hs binary locations instead of hardcoding /opt/homebrew/bin/hs, since AppleScript do shell script runs with a minimal PATH.